### PR TITLE
CLIM-221 Add explicit slugs to sites and maintenance template

### DIFF
--- a/.github/ISSUE_TEMPLATE/maintainance-event.md
+++ b/.github/ISSUE_TEMPLATE/maintainance-event.md
@@ -8,9 +8,9 @@ assignees: ''
 ---
 
 <!--
-start: 2025-05-27T19:30:00.000Z
-end: 2025-05-27T22:15:00.000Z
-expectedDown: ClinicSites.co, Clinic-Sites-Preview, Clinic-Sites-Live-Domain
+start: 2026-01-13T13:00:00+00:00
+end: 2026-01-13T14:30:00+00:00
+expectedDown: janewebsites-com, janewebsites-site-preview, janewebsites-live-domain
 -->
 **Additional context**
 Scheduled maintenance window setup to perform system updates.

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -6,12 +6,15 @@ repo: clinic-sites-uptime
 sites:
   - name: JaneWebsites.com
     url: https://janewebsites.com
+    slug: janewebsites-com
   - name: Jane Websites Site Preview
     url: https://template1.janewebsites.com
     faviconSvg: https://icons.duckduckgo.com/ip3/janewebsites.com.ico
+    slug: janewebsites-site-preview
   - name: Jane Websites Live Domain
     url: $CLINIC_SITES_LIVE_DOMAIN
     favicon: https://icons.duckduckgo.com/ip3/janewebsites.com.ico
+    slug: janewebsites-live-domain
 assignees:
   - James-Pike-Jane
   - brycemevans-jane


### PR DESCRIPTION
The Upptime scheduled maintenance
[docs](https://upptime.js.org/docs/scheduled-maintenance) at https://upptime.js.org/docs/scheduled-maintenance call out slugs as the items to list when scheduling downtime.

> Both these keys should have comma-separated list of *slugs.*

We'll add explicit slugs to our config so folks are not guessing at the values that should go into the scheduled down time and where they came from. Including the slugs on the maintenance event template will also improve clarity when creating a downtime event.

There's no clear information that converting to ISO timestamps with `+` (`2026-01-13T13:00:00+00:00`) from ISO timestamps with a letter, (`2026-01-13T04:20:00.000Z`) will make a difference in our upptime reporting and we want to keep the space for error as small as possible in our up-time monitoring tools.