### PR TITLE
Bump uptime-monitor to v1.42.6 to fix Uptime CI on Node 24

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -33,20 +33,20 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "update-template"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}
           SECRETS_CONTEXT: '{"CLINIC_SITES_LIVE_DOMAIN": "${{ secrets.CLINIC_SITES_LIVE_DOMAIN }}"}'
       - name: Update summary in README
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "readme"
         env:
@@ -57,7 +57,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "readme"
         env:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update template
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "update-template"
         env:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -32,6 +32,6 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update code
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+        uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
         with:
           command: "update"
         env:


### PR DESCRIPTION
## Summary

Bumps the `upptime/uptime-monitor` action pin from **v1.41.0** to **v1.42.6** across all eight workflow files. This fixes **Uptime CI** (and the other Upptime workflows), which began failing on 2026-06-17 once GitHub started forcing Node 24 on Actions runners.

## Root cause

GitHub is [removing Node 20 from runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and now forces **Node 24**. Our pinned `v1.41.0` action declares `runs.using: "node20"` and ships a `node-libcurl` native binary compiled for the Node 20 ABI (`NODE_MODULE_VERSION 115`). Under Node 24 (ABI `137`) the binary fails to load, crashing the job before any endpoint is checked:

```
Error: ... node_libcurl.node was compiled against a different Node.js version using
NODE_MODULE_VERSION 115. This version of Node.js requires NODE_MODULE_VERSION 137.
```

This is a recurring upstream Upptime issue on every runner Node bump — see [upptime/upptime#800](https://github.com/upptime/upptime/issues/800).

## The fix

Upstream **v1.42.6** (commit [`940c360e`](https://github.com/upptime/uptime-monitor/commit/940c360e6ee3b3f43b234e56a79e15c76a0c6c2e)) declares `runs.using: "node24"` with a recompiled binary, so the action's runtime matches the runner.

```
- uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
+ uses: upptime/uptime-monitor@940c360e6ee3b3f43b234e56a79e15c76a0c6c2e # v1.42.6
```

SHA pinning is preserved, only the pinned commit and version comment change. The SHA was verified against the tag list, the commit object (`:bookmark: Release v1.42.6`), and the `action.yml` read at that SHA.

## Files changed (11 occurrences)

| File | occurrences |
| --- | --- |
| `uptime.yml`, `response-time.yml`, `graphs.yml`, `summary.yml`, `site.yml`, `updates.yml`, `update-template.yml` | 1 each |
| `setup.yml` | 4 |

`actions/checkout@…# v4` and the other actions are intentionally left unchanged — `checkout` is pure JS and runs fine on Node 24 (deprecation warning only).

## Verification

After merge, manually dispatch **Uptime CI** on `master` and confirm the run is green with no `NODE_MODULE_VERSION` error in the log. (The "Node 20 deprecated → forced to Node 24" warning for `actions/checkout` is expected and harmless.)
